### PR TITLE
Adds rack 1.6.4 to Gemfile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /config/quickets.yml
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'roda'
 gem 'rack-cors'
+gem 'rack', '~> 1.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (1.6.4)
+    rack-cors (0.4.0)
+    roda (2.18.0)
+      rack
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack (~> 1.6.4)
+  rack-cors
+  roda
+
+BUNDLED WITH
+   1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       rack
 
 PLATFORMS
-  ruby
+  java
 
 DEPENDENCIES
   rack (~> 1.6.4)


### PR DESCRIPTION
Quicket relies on rack which has been updated recently and relies on Ruby >=2.2.2 
The following error is generated.

**ERROR: Error installing rack:
rack requires Ruby version >= 2.2.2.**
